### PR TITLE
ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO doesn't take class_name

### DIFF
--- a/sample.c
+++ b/sample.c
@@ -3,8 +3,10 @@
 /*
  1. define the arguments *_EX allows to define the number of required arguments in the third parameter
 
- ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO(name, type, class_name, allow_null)
- ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(name, return_reference, required_num_args, type, class_name, allow_null)
+ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO(name, allow_null)
+ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(name, return_reference, required_num_args, class_name, allow_null)
+ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO(name, class_name, allow_null)
+ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(name, return_reference, required_num_args, type, allow_null)
  */
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(ArgInfo_sample_multiply, 0, 1, IS_LONG, NULL, 0)
 	ZEND_ARG_TYPE_INFO(0, first, IS_LONG, 0)


### PR DESCRIPTION
Added `ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO` in comment

See https://github.com/php/php-src/blob/c265652879eb552d4bbd6d94eeb2ac87beac8df0/Zend/zend_API.h#L107

```c
#define ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(name, return_reference, required_num_args, class_name, allow_null) \
	static const zend_internal_arg_info name[] = { \
		{ (const char*)(zend_uintptr_t)(required_num_args), ZEND_TYPE_ENCODE_CLASS_CONST(#class_name, allow_null), return_reference, 0 },

#define ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO(name, class_name, allow_null) \
	ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(name, 0, -1, class_name, allow_null)

#define ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(name, return_reference, required_num_args, type, allow_null) \
	static const zend_internal_arg_info name[] = { \
		{ (const char*)(zend_uintptr_t)(required_num_args), ZEND_TYPE_ENCODE(type, allow_null), return_reference, 0 },
#define ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO(name, type, allow_null) \
	ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(name, 0, -1, type, allow_null)
```